### PR TITLE
check scope_changed? again if it was false in the same transaction

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -241,9 +241,6 @@ module ActiveRecord
             increment_positions_on_lower_items(self[position_column], id)
           end
 
-          # Make sure we know that we've processed this scope change already
-          @scope_changed = false
-
           # Don't halt the callback chain
           true
         end
@@ -255,16 +252,13 @@ module ActiveRecord
             increment_positions_on_lower_items(self[position_column], id)
           end
 
-          # Make sure we know that we've processed this scope change already
-          @scope_changed = false
-
           # Don't halt the callback chain
           true
         end
 
         def assume_default_position?
           not_in_list? ||
-          persisted? && internal_scope_changed? && !position_changed ||
+          persisted? && @scope_changed && !position_changed ||
           default_position?
         end
 
@@ -445,7 +439,7 @@ module ActiveRecord
         end
 
         def internal_scope_changed?
-          return @scope_changed if defined?(@scope_changed)
+          return false if defined?(@scope_changed) && @scope_changed
 
           @scope_changed = scope_changed?
         end

--- a/lib/acts_as_list/active_record/acts/scope_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/scope_method_definer.rb
@@ -17,7 +17,7 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
         end
 
         define_method :scope_changed? do
-          changed.include?(scope_name.to_s)
+          changed.include?(scope_name.to_s) && !changes[scope_name.to_s][0].nil?
         end
 
         define_method :destroyed_via_scope? do

--- a/test/shared_list.rb
+++ b/test/shared_list.rb
@@ -310,5 +310,33 @@ module Shared
         new.insert_at!(1)
       end
     end
+
+    def test_update_scope__with_in_transaction
+      ActiveRecord::Base.transaction do
+        new1 = ListMixin.create(parent_id: 100)
+        assert_equal 1, new1.pos
+
+        new2 = ListMixin.create(parent_id: 200)
+        assert_equal 1, new2.pos
+
+        new1.update_attributes(parent_id: 20)
+        assert_equal 1, new1.pos
+
+        new2.update_attributes(parent_id: 20)
+        assert_equal 2, new2.pos
+      end
+
+      new1 = ListMixin.create(parent_id: 300)
+      assert_equal 1, new1.pos
+
+      new2 = ListMixin.create(parent_id: 400)
+      assert_equal 1, new2.pos
+
+      new1.update_attributes(parent_id: 30)
+      assert_equal 1, new1.pos
+
+      new2.update_attributes(parent_id: 30)
+      assert_equal 2, new2.pos
+    end
   end
 end


### PR DESCRIPTION
If `@scope_changed` is set to false in a transaction, it will never run the `check_scope` logic in the same transaction 