### PR TITLE
Silence deprecation warning in rails 6

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -8,10 +8,18 @@ appraise "rails-4-2" do
   group :test do
     gem "test_after_commit", "~> 0.4.2"
   end
+  group :sqlite do
+    gem "sqlite3", "~> 1.3.13"
+  end
+
   gem "activerecord", "~> 4.2.0"
 end
 
 appraise "rails-5-0" do
+  group :sqlite do
+    gem "sqlite3", "~> 1.3.13"
+  end
+
   gem "activerecord", "~> 5.0.0"
 end
 
@@ -24,8 +32,5 @@ appraise "rails-5-2" do
 end
 
 appraise "rails-6-0" do
-  group :sqlite do
-    gem "sqlite3", "~> 1.4"
-  end
   gem "activerecord", "~> 6.0.0"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :test do
 end
 
 group :sqlite do
-  gem "sqlite3", "~> 1.3.13"
+  gem "sqlite3", "~> 1.4"
 end
 
 group :postgresql do

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -17,7 +17,7 @@ group :test do
 end
 
 group :sqlite do
-  gem "sqlite3", "~> 1.3.13"
+  gem "sqlite3", "~> 1.4"
 end
 
 group :postgresql do

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -17,7 +17,7 @@ group :test do
 end
 
 group :sqlite do
-  gem "sqlite3", "~> 1.3.13"
+  gem "sqlite3", "~> 1.4"
 end
 
 group :postgresql do

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -226,7 +226,7 @@ module ActiveRecord
         end
 
         def acts_as_list_list
-          acts_as_list_class.unscope(:select, :where).where(scope_condition)
+          acts_as_list_class.unscoped.where(scope_condition)
         end
 
         # Poorly named methods. They will insert the item at the desired position if the position

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -51,3 +51,19 @@ def assert_equal_or_nil(a, b)
     assert_equal a, b
   end
 end
+
+def assert_no_deprecation_warning_raised_by(&block)
+  original_behavior = ActiveSupport::Deprecation.behavior
+  ActiveSupport::Deprecation.behavior = :raise
+  begin
+    block.call
+  rescue ActiveSupport::DeprecationException
+    flunk "Deprecation warnings raised when using find_or_create_by and we didn't expect it"
+  rescue
+    raise
+  else
+    pass "No dep warning raised, no other exception raised either"
+  end
+ensure
+  ActiveSupport::Deprecation.behavior = original_behavior
+end

--- a/test/shared_list.rb
+++ b/test/shared_list.rb
@@ -314,5 +314,11 @@ module Shared
         new.insert_at!(1)
       end
     end
+
+    def test_find_or_create_doesnt_raise_deprecation_warning
+      assert_no_deprecation_warning_raised_by do
+        ListMixin.where(parent_id: 5).find_or_create_by(pos: 5)
+      end
+    end
   end
 end

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -419,6 +419,12 @@ class DefaultScopedTest < ActsAsListTestCase
     assert_equal_or_nil $default_position, new_noup.pos
   end
 
+  def test_find_or_create_doesnt_raise_deprecation_warning
+    assert_no_deprecation_warning_raised_by do
+      DefaultScopedMixin.find_or_create_by(pos: 5)
+    end
+  end
+
   def test_update_position
     assert_equal [1, 2, 3, 4], DefaultScopedMixin.all.map(&:id)
     DefaultScopedMixin.where(id: 2).first.set_list_position(4)
@@ -521,6 +527,12 @@ class DefaultScopedWhereTest < ActsAsListTestCase
 
     new_noup.reload
     assert_equal_or_nil $default_position, new_noup.pos
+  end
+
+  def test_find_or_create_doesnt_raise_deprecation_warning
+    assert_no_deprecation_warning_raised_by do
+      DefaultScopedWhereMixin.find_or_create_by(pos: 5)
+    end
   end
 
   def test_update_position
@@ -642,6 +654,12 @@ class MultipleListsTest < ActsAsListTestCase
     ListMixin.find(4).update :parent_id => 2, :pos => 2
     assert_equal [1, 2, 3], ListMixin.where(:parent_id => 1).order('pos').map(&:pos)
     assert_equal [1, 2, 3, 4, 5], ListMixin.where(:parent_id => 2).order('pos').map(&:pos)
+  end
+
+  def test_find_or_create_doesnt_raise_deprecation_warning
+    assert_no_deprecation_warning_raised_by do
+      ListMixin.where(:parent_id => 1).find_or_create_by(pos: 5)
+    end
   end
 end
 


### PR DESCRIPTION
In rails 6 we get the following deprecation warning:

    DEPRECATION WARNING: Class level methods will no longer inherit
    scoping from `create` in Rails 6.1. To continue using the scoped
    relation, pass it into the block directly. To instead access the full
    set of models, as Rails 6.1 will, use `<model name>.unscoped`.
    (called from acts_as_list_list at /path/to/acts_as_list/lib/acts_as_list/active_record/acts/list.rb:229)

when we call `find_or_create_by` on a model with `acts_as_list`.  To get
rid of this deprecation warning, we need to use the full `unscoped` method
instead of the restricted `unscope(:select, :where)`.

No other tests seem to break with this change, so I assume fully unscoping isn't going to cause any problems elsewhere in how `acts_as_list` works.

In the first commit I've also tweaked the Gemfile and Appraisals files to work out of the box now that rails 6 is available and it doesn't work with sqlite 1.3.