### PR TITLE
Invert order when incrementing to circumvent unique index violations

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -312,7 +312,11 @@ module ActiveRecord
             scope = scope.where("#{quoted_table_name}.#{self.class.primary_key} != ?", avoid_id)
           end
 
-          scope.where("#{quoted_position_column_with_table_name} >= ?", position).increment_all
+          if sequential_updates?
+            scope.where("#{quoted_position_column_with_table_name} >= ?", position).reorder(acts_as_list_order_argument(:desc)).increment_sequentially
+          else
+            scope.where("#{quoted_position_column_with_table_name} >= ?", position).increment_all
+          end
         end
 
         # This has the effect of moving all the higher items up one.

--- a/test/test_list.rb
+++ b/test/test_list.rb
@@ -995,6 +995,11 @@ class SequentialUpdatesMixinNotNullUniquePositiveConstraintsTest < ActsAsListTes
       assert_equal 3, new.pos
     end
 
+    def test_create_at_top
+      new = SequentialUpdatesAltId.create!(pos: 1)
+      assert_equal 1, new.pos
+    end
+
     def test_move_to_bottom
       item = SequentialUpdatesAltId.order(:pos).first
       item.move_to_bottom


### PR DESCRIPTION
I use this gem in combination with an unique index. When I try to insert a new item at the top of the list I get `Mysql2::Error: Duplicate entry` error in the `increment_positions_on_lower_items` method.

This is because MySQL checks on each updated row if it violates the unique index, even when the update statement is called inside of an transaction.

The reversed order fixes this bug by incrementing the 'highest' values first so the unique index is still unique on every row.