### PR TITLE
Add test case for moving items between lists with unique constraint

### DIFF
--- a/test/test_move_between_lists.rb
+++ b/test/test_move_between_lists.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'helper'
+
+class TestMoveBetweenLists < Minitest::Test
+  class Section < ActiveRecord::Base
+    has_many :items
+  end
+
+  class Item < ActiveRecord::Base
+    belongs_to :section
+    acts_as_list scope: :section, sequential_updates: true
+  end
+
+  def setup
+    ActiveRecord::Base.connection.create_table :sections do |t|
+    end
+
+    ActiveRecord::Base.connection.create_table :items do |t|
+      t.column :section_id, :integer
+      t.column :position, :integer
+    end
+
+    ActiveRecord::Base.connection.add_index :items, %i[position section_id], unique: true
+
+    ActiveRecord::Base.connection.schema_cache.clear!
+    [Section, Item].each(&:reset_column_information)
+    super
+  end
+
+  def teardown
+    teardown_db
+    super
+  end
+
+  def test_move_to_another_section
+    section1 = Section.create
+    section1_item1 = Item.create section: section1
+    section1_item2 = Item.create section: section1
+    section1_item3 = Item.create section: section1
+
+    section2 = Section.create
+    section2_item1 = Item.create section: section2
+    section2_item2 = Item.create section: section2
+    section2_item3 = Item.create section: section2
+
+    section1_item2.update! section: section2
+
+    assert_equal [section1.id, 1], [section1_item1.section_id, section1_item1.position]
+    assert_equal [section2.id, 4], [section1_item2.section_id, section1_item2.position]
+    assert_equal [section1.id, 3], [section1_item3.section_id, section1_item3.position] # Shouldn't this be position 2?
+
+    assert_equal [section2.id, 1], [section2_item1.section_id, section2_item1.position]
+    assert_equal [section2.id, 2], [section2_item2.section_id, section2_item2.position]
+    assert_equal [section2.id, 3], [section2_item3.section_id, section2_item3.position]
+  end
+end


### PR DESCRIPTION
This PR is maybe more of an issue than an actual PR but since I wrote a test case to validate the problem for myself before opening an issue, I thought let's just include that in a PR. 

So the issue is when you have two scoped lists and you move an item between two lists, the database will complain about a unique constraint (if you have one of course). 

It fails since the gem wants to move all the lower items in the old list up by 1 before the item has actually switched the list. I had a quick trial en error way of trying to fix this. It is all about the `List#check_scope` method where the order is basically wrong but just changing the order fails a lot of other specs. So some help here would be really helpful 😄 

In addition to this, if I remove the unique constraint, the 'old' list has positions `[1, 3]` instead of `[1, 2]`. Guess that's also not what is expected right?