### PR TITLE
gemspec: Drop defunct rubyforge_project directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Removed
+
+- gemspec: Drop defunct `rubyforge_project` directive [\#373](https://github.com/brendon/acts_as_list/pull/373) ([olleolleolle])
+
+[olleolleolle]: https://github.com/olleolleolle
+
 ## v1.0.1 - 2020-02-27
 
 ### Fixed

--- a/acts_as_list.gemspec
+++ b/acts_as_list.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.summary               = "A gem adding sorting, reordering capabilities to an active_record model, allowing it to act as a list"
   s.description           = 'This "acts_as" extension provides the capabilities for sorting and reordering a number of objects in a list. The class that has this specified needs to have a "position" column defined as an integer on the mapped database table.'
   s.license               = "MIT"
-  s.rubyforge_project     = "acts_as_list"
   s.required_ruby_version = ">= 2.4.7"
 
   if s.respond_to?(:metadata)


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* rubygems/rubygems#2436 deprecated the `rubyforge_project` property.

[1]: https://twitter.com/evanphx/status/399552820380053505
