### PR TITLE
Doc: Use `String#squish` instead of `#squeeze` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ end
 When using PostgreSQL, it is also possible to leave this migration up to the database layer. Inside of the `change` block you could write:
 
 ```ruby
- execute <<~SQL.squeeze
+ execute <<~SQL.squish
    UPDATE todo_items
    SET position = mapping.new_position
    FROM (


### PR DESCRIPTION
`#squeeze` removes all repeated characters, while `#squish` only acts on whitespace. I was getting a very confusing SQL error about my table with `tt`s.