### PR TITLE
Get foreign key from reflections when possible

### DIFF
--- a/lib/acts_as_list/active_record/acts/scope_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/scope_method_definer.rb
@@ -4,7 +4,7 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
   extend ActiveSupport::Inflector
 
   def self.call(caller_class, scope)
-    scope = idify(scope) if scope.is_a?(Symbol)
+    scope = idify(caller_class, scope) if scope.is_a?(Symbol)
 
     caller_class.class_eval do
       define_method :scope_name do
@@ -64,9 +64,13 @@ module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
     end
   end
 
-  def self.idify(name)
+  def self.idify(caller_class, name)
     return name if name.to_s =~ /_id$/
 
-    foreign_key(name).to_sym
+    if caller_class.reflections.key?(name.to_s)
+      caller_class.reflections[name.to_s].foreign_key.to_sym
+    else
+      foreign_key(name).to_sym
+    end
   end
 end

--- a/test/test_scope_with_user_defined_foreign_key.rb
+++ b/test/test_scope_with_user_defined_foreign_key.rb
@@ -1,0 +1,42 @@
+require 'helper'
+
+class Checklist < ActiveRecord::Base
+  has_many :checklist_items, foreign_key: 'list_id', inverse_of: :checklist
+end
+
+class ChecklistItem < ActiveRecord::Base
+  belongs_to :checklist, foreign_key: 'list_id', inverse_of: :checklist_items
+  acts_as_list scope: :checklist
+end
+
+class ScopeWithUserDefinedForeignKeyTest < Minitest::Test
+  def setup
+    ActiveRecord::Base.connection.create_table :checklists do |t|
+    end
+
+    ActiveRecord::Base.connection.create_table :checklist_items do |t|
+      t.column :list_id, :integer
+      t.column :position, :integer
+    end
+
+    ActiveRecord::Base.connection.schema_cache.clear!
+    [Checklist, ChecklistItem].each(&:reset_column_information)
+    super
+  end
+
+  def teardown
+    teardown_db
+    super
+  end
+
+  def test_scope_with_user_defined_foreign_key
+    checklist = Checklist.create
+    checklist_item_1 = checklist.checklist_items.create
+    checklist_item_2 = checklist.checklist_items.create
+    checklist_item_3 = checklist.checklist_items.create
+
+    assert_equal 1, checklist_item_1.position
+    assert_equal 2, checklist_item_2.position
+    assert_equal 3, checklist_item_3.position
+  end
+end


### PR DESCRIPTION
This is useful for associations with user-defined foreign keys that do not follow the convention of a lowercased class name followed by an "_id" suffix.