### PR TITLE
Add explicit requirement of ActiveSupport::Inflector. Fixes #386

### DIFF
--- a/lib/acts_as_list/active_record/acts/scope_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/scope_method_definer.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "active_support/inflector"
 
 module ActiveRecord::Acts::List::ScopeMethodDefiner #:nodoc:
   extend ActiveSupport::Inflector


### PR DESCRIPTION
This adds an explicit requirement of `ActiveSupport::Inflector`, which solves #386.

Using this `Gemfile`:

```
source "https://rubygems.org"
gem "activerecord"
gem "acts_as_list"
```

The following will now work:

```
bundle install
bundle console # would fail previously
```
