### PR TITLE
Enhancement: Execute show table queries through schema cache class

### DIFF
--- a/lib/acts_as_list/active_record/acts/sequential_updates_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/sequential_updates_method_definer.rb
@@ -6,11 +6,12 @@ module ActiveRecord::Acts::List::SequentialUpdatesMethodDefiner #:nodoc:
       define_method :sequential_updates? do
         if !defined?(@sequential_updates)
           if sequential_updates_option.nil?
+            schema_connection = caller_class.connection.respond_to?(:schema_cache) ? caller_class.connection.schema_cache : caller_class.connection
             table_exists =
               if active_record_version_is?('>= 5')
-                caller_class.connection.data_source_exists?(caller_class.table_name)
+                schema_connection.data_source_exists?(caller_class.table_name)
               else
-                caller_class.connection.table_exists?(caller_class.table_name)
+                schema_connection.table_exists?(caller_class.table_name)
               end
             index_exists = caller_class.connection.index_exists?(caller_class.table_name, column, unique: true)
             @sequential_updates = table_exists && index_exists


### PR DESCRIPTION
Background: 
------------------
Executing `connection.data_source_exists?` or `connection.table_exists?` will fire `SHOW TABLES LIKE 'table_name'` query. When this is invoked n times, then n number of show table queries will be fired. 

Enhancement: 
------------------
Starting ActiveRecord version >= 3.2 schema cache class is used as a gateway for executing all show table queries. Example: `connection.schema_cache.table_exists?` will fire show query table once and will cache the results in its objects. Further invocations of show table queries are referred from the objects rather than firing every time to the database. 

Benefits
------------------
For a larger production system with several databases, this would reduce several show table queries getting fired to databases and reduces the load on the system. 

PS: My First OpenSource pull request please let me know for any feedbacks. :) 

