### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,110 @@
+---
+name: CI
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: Ruby ${{ matrix.ruby }}, ${{ matrix.gemfile }}, DB ${{ matrix.db }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+          - '3.0'
+          - 3.1
+        gemfile:
+          - gemfiles/rails_4_2.gemfile
+          - gemfiles/rails_5_0.gemfile
+          - gemfiles/rails_5_1.gemfile
+          - gemfiles/rails_5_2.gemfile
+          - gemfiles/rails_6_0.gemfile
+          - gemfiles/rails_6_1.gemfile
+          - gemfiles/rails_7_0.gemfile
+        db:
+          - sqlite
+          - mysql
+          - postgresql
+        exclude:
+          - ruby: 2.4
+            gemfile: gemfiles/rails_6_0.gemfile
+          - ruby: 2.4
+            gemfile: gemfiles/rails_6_1.gemfile
+          - ruby: 2.4
+            gemfile: gemfiles/rails_7_0.gemfile
+          - ruby: 2.5
+            gemfile: gemfiles/rails_7_0.gemfile
+          - ruby: 2.6
+            gemfile: gemfiles/rails_7_0.gemfile
+          - ruby: 2.7
+            gemfile: gemfiles/rails_4_2.gemfile
+          - ruby: 2.7
+            gemfile: gemfiles/rails_5_0.gemfile
+            db: sqlite
+          - ruby: '3.0'
+            gemfile: gemfiles/rails_4_2.gemfile
+          - ruby: '3.0'
+            gemfile: gemfiles/rails_5_0.gemfile
+          - ruby: '3.0'
+            gemfile: gemfiles/rails_5_1.gemfile
+          - ruby: '3.0'
+            gemfile: gemfiles/rails_5_2.gemfile
+          - ruby: 3.1
+            gemfile: gemfiles/rails_4_2.gemfile
+          - ruby: 3.1
+            gemfile: gemfiles/rails_5_0.gemfile
+          - ruby: 3.1
+            gemfile: gemfiles/rails_5_1.gemfile
+          - ruby: 3.1
+            gemfile: gemfiles/rails_5_2.gemfile
+          - ruby: 3.1
+            gemfile: gemfiles/rails_6_0.gemfile
+        os:
+          - ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+            MYSQL_ALLOW_EMPTY_PASSWORD: yes
+        ports:
+            - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      BUNDLE_GEMFILE: ${{ matrix.gemfile }}
+      DB: ${{ matrix.db }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: "Create MySQL database"
+        if: ${{ env.DB == 'mysql' }}
+        run: |
+          mysql -h 127.0.0.1 -u root -e 'create database acts_as_list;'
+      - name: "Create PostgreSQL database"
+        if: ${{ env.DB == 'postgresql' }}
+        run: |
+          psql -c 'create database acts_as_list;' -h localhost -U postgres
+      - name: Run tests
+        run: bundle exec rake 

--- a/Appraisals
+++ b/Appraisals
@@ -36,5 +36,9 @@ appraise "rails-6-0" do
 end
 
 appraise "rails-6-1" do
-  gem "activerecord", "6.1.0.rc1"
+  gem "activerecord", "~> 6.1.0"
+end
+
+appraise "rails-7-0" do
+  gem "activerecord", "~> 7.0.0"
 end

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -4,10 +4,10 @@ source "http://rubygems.org"
 
 gem "rake"
 gem "appraisal"
-gem "activerecord", "~> 6.1.0"
+gem "activerecord", "~> 7.0.0"
 
 group :development do
-  gem "github_changelog_generator", "1.9.0"
+  gem "github_changelog_generator", "~> 1.16.0"
 end
 
 group :test do
@@ -21,7 +21,7 @@ group :sqlite do
 end
 
 group :postgresql do
-  gem "pg", "~> 1.2.0"
+  gem "pg", "~> 1.3.0"
 end
 
 group :mysql do

--- a/test/database.yml
+++ b/test/database.yml
@@ -4,13 +4,15 @@ sqlite:
 
 mysql:
   adapter: mysql2
+  host: 127.0.0.1
   username: root
   password:
   database: acts_as_list
 
 postgresql:
   adapter: postgresql
+  host: localhost
   username: postgres
-  password:
+  password: postgres
   database: acts_as_list
   min_messages: ERROR


### PR DESCRIPTION
As Travis CI.org is no longer operational, the existing CI for this repo doesn't run anymore.

This PR switches CI to GitHub actions.  It also expands the CI matrix to include Ruby 3.1 and Rails 7.

Runs green on my fork.