### PR TITLE
Use after_save instead of after_commit for clear_scope_changed callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- Use `after_save` instead of `after_commit` for `clear_scope_changed` callback [\#407](https://github.com/brendon/acts_as_list/pull/407) ([@Flixt](https://github.com/Flixt))
+
 ## v1.0.4 - 2021-04-20
 
 ### Fixed

--- a/lib/acts_as_list/active_record/acts/callback_definer.rb
+++ b/lib/acts_as_list/active_record/acts/callback_definer.rb
@@ -11,7 +11,7 @@ module ActiveRecord::Acts::List::CallbackDefiner #:nodoc:
       before_update :check_scope, unless: :act_as_list_no_update?
       after_update :update_positions, unless: :act_as_list_no_update?
 
-      after_commit :clear_scope_changed
+      after_save :clear_scope_changed
 
       if add_new_at.present?
         before_create "add_to_list_#{add_new_at}".to_sym, unless: :act_as_list_no_update?


### PR DESCRIPTION
The problem is, when running multiple updates of the same objects within the same transaction, only firing `clear_scope_changed` after the transaction commit can lead to duplicate positions.

Without the change the test included in this PR fails with (run with `ruby -I test test/test_list.rb --name test_multiple_updates_within_transaction`):

```
Run options: --name test_multiple_updates_within_transaction --seed 61388

# Running:

F

Finished in 0.025951s, 38.5342 runs/s, 269.7391 assertions/s.

  1) Failure:
MultiUpdateTest#test_multiple_updates_within_transaction [test/test_list.rb:668]:
Expected: [1, 2]
  Actual: [1, 1]

1 runs, 7 assertions, 1 failures, 0 errors, 0 skips
```

Actually I have no idea if changing this callback from `after_commit` to after_save` is the "correct" way to fix this.