### PR TITLE
Avoid collision when add_new_at is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Use `after_save` instead of `after_commit` for `clear_scope_changed` callback [\#407](https://github.com/brendon/acts_as_list/pull/407) ([@Flixt](https://github.com/Flixt))
+- Rename `add_to_list_top` and `add_to_list_bottom` private methods to `avoid_collision` that handles both cases as well as the case where `:add_new_at` is `nil`. Setting an explicit position when `:add_new_at` is `nil` will now shuffle other items out of the way if necessary. [\#411](https://github.com/brendon/acts_as_list/pull/411). ([brendon])
 
 ## v1.0.4 - 2021-04-20
 

--- a/lib/acts_as_list/active_record/acts/callback_definer.rb
+++ b/lib/acts_as_list/active_record/acts/callback_definer.rb
@@ -13,9 +13,7 @@ module ActiveRecord::Acts::List::CallbackDefiner #:nodoc:
 
       after_save :clear_scope_changed
 
-      if add_new_at.present?
-        before_create "add_to_list_#{add_new_at}".to_sym, unless: :act_as_list_no_update?
-      end
+      before_create :avoid_collision, unless: :act_as_list_no_update?
     end
   end
 end

--- a/test/shared_no_addition.rb
+++ b/test/shared_no_addition.rb
@@ -34,5 +34,40 @@ module Shared
       new.reload
       assert !new.in_list?
     end
+
+    def test_collision_avoidance_with_explicit_position
+      first = NoAdditionMixin.create(parent_id: 20, pos: 1)
+      second = NoAdditionMixin.create(parent_id: 20, pos: 1)
+      third = NoAdditionMixin.create(parent_id: 30, pos: 1)
+
+      first.reload
+      second.reload
+      third.reload
+
+      assert_equal 2, first.pos
+      assert_equal 1, second.pos
+      assert_equal 1, third.pos
+
+      first.update(pos: 1)
+
+      first.reload
+      second.reload
+
+      assert_equal 1, first.pos
+      assert_equal 2, second.pos
+
+      first.update(parent_id: 30)
+
+      first.reload
+      second.reload
+      third.reload
+
+      assert_equal 1, first.pos
+      assert_equal 30, first.parent_id
+      assert_equal 1, second.pos
+      assert_equal 20, second.parent_id
+      assert_equal 2, third.pos
+      assert_equal 30, third.parent_id
+    end
   end
 end


### PR DESCRIPTION
Rename `add_to_list_top` and `add_to_list_bottom` private methods to `avoid_collision` that handles both cases as well as the case where `:add_new_at` is `nil`. Setting an explicit position when `:add_new_at` is `nil` will now shuffle other items out of the way if necessary.

Fixes #410