### PR TITLE
Remove branch assume_default_position? in add_new_at

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -232,12 +232,7 @@ module ActiveRecord
         def avoid_collision
           case add_new_at
           when :top
-            if assume_default_position?
-              increment_positions_on_all_items
-              self[position_column] = acts_as_list_top
-            else
-              increment_positions_on_lower_items(self[position_column], id)
-            end
+            increment_positions_on_lower_items(self[position_column], id)
           when :bottom
             if assume_default_position?
               self[position_column] = bottom_position_in_list.to_i + 1


### PR DESCRIPTION
The following is the case of a premise, the movement of position will be incorrect.

### Prerequisites
|top_of_list|add_new_at|default_position|
|-|-|-|
|0|:top|1|

e.g. Add a record with position 1
|id|name|position|
|-|-|-|
|1|aaaaa|0|

↓

|id|name|position|
|-|-|-|
|1|aaaaa|1|
|2|bbbbb|0|

### Reason
When the default position is 1, the value of `assume_default_position?` is true.
Then, `increment_positions_on_all_items` turns a record in position 0 into position 1.
Finally, `acts_as_list_top` (0) is assigned to the record in position 1.

```
          when :top
            if assume_default_position?
              increment_positions_on_all_items
              self[position_column] = acts_as_list_top
```
https://github.com/brendon/acts_as_list/blob/master/lib/acts_as_list/active_record/acts/list.rb#L234-L237

### Solution
We do not consider the assignments of `increment_positions_on_all_items` and `acts_as_list_top` to be necessary.
Only `increment_positions_on_lower_items` works fine.
