### PR TITLE
refactor: memoize record loads in `move_(higher|lower)`

### DIFF
--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -82,13 +82,13 @@ module ActiveRecord
 
         # Swap positions with the next lower item, if one exists.
         def move_lower
-          return unless lower_item
+          return unless (other = lower_item)
 
           acts_as_list_class.transaction do
-            if lower_item.current_position != current_position
-              swap_positions_with(lower_item)
+            if other.current_position != current_position
+              swap_positions_with(other)
             else
-              lower_item.decrement_position
+              other.decrement_position
               increment_position
             end
           end
@@ -96,13 +96,13 @@ module ActiveRecord
 
         # Swap positions with the next higher item, if one exists.
         def move_higher
-          return unless higher_item
+          return unless (other = higher_item)
 
           acts_as_list_class.transaction do
-            if higher_item.current_position != current_position
-              swap_positions_with(higher_item)
+            if other.current_position != current_position
+              swap_positions_with(other)
             else
-              higher_item.increment_position
+              other.increment_position
               decrement_position
             end
           end

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,6 +1,6 @@
 sqlite:
   adapter: sqlite3
-  database: "file:memdb1?mode=memory&cache=shared"
+  database: ":memory:"
 
 mysql:
   adapter: mysql2


### PR DESCRIPTION
Heyo 👋🏻 I work at [Procore](github.com/procore), and we're looking at the performance (in particular - the database query pressure) of `acts_as_list`. I _think_ this PR should be a quick win, but I'm hoping we can contribute a number of performance improvements over time. Happy to chat and swap notes if that'd ever be helpful.

`lower_item` makes a DB call; memoizing it in `move_lower` allows us to save a few queries. (Sim. `higher_item` and `move_higher`).