### PR TITLE
Add ActiveRecord 7.1 to appraisal and fix deprecation warning

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -42,3 +42,7 @@ end
 appraise "rails-7-0" do
   gem "activerecord", "~> 7.0.0"
 end
+
+appraise "rails-7-1" do
+  gem "activerecord", "~> 7.1.0"
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -53,8 +53,8 @@ def assert_equal_or_nil(a, b)
 end
 
 def assert_no_deprecation_warning_raised_by(failure_message = 'ActiveRecord deprecation warning raised when we didn\'t expect it', pass_message = 'No ActiveRecord deprecation raised')
-  original_behavior = ActiveSupport::Deprecation.behavior
-  ActiveSupport::Deprecation.behavior = :raise
+  original_behavior = active_record_deprecator.behavior
+  active_record_deprecator.behavior = :raise
   begin
     yield
   rescue ActiveSupport::DeprecationException => e
@@ -65,5 +65,13 @@ def assert_no_deprecation_warning_raised_by(failure_message = 'ActiveRecord depr
     pass pass_message
   end
 ensure
-  ActiveSupport::Deprecation.behavior = original_behavior
+  active_record_deprecator.behavior = original_behavior
+end
+
+def active_record_deprecator
+  if ActiveRecord::VERSION::MAJOR == 7 && ActiveRecord::VERSION::MINOR >= 1 || ActiveRecord::VERSION::MAJOR > 7
+    ActiveRecord.deprecator
+  else
+    ActiveSupport::Deprecation
+  end
 end


### PR DESCRIPTION
Set the deprecation behavior on ActiveRecord.deprecator, instead of ActiveSupport::Deprecation, as that is deprecated. Fixes the following warnings:

      ActiveSupport::DeprecationException: DEPRECATION WARNING: Calling
      behavior= on ActiveSupport::Deprecation is deprecated and will be
      removed from Rails (use Rails.application.deprecators.behavior=
      instead)