### PR TITLE
Don't delegate `connection` to `self`

### DIFF
--- a/lib/acts_as_list/active_record/acts/position_column_method_definer.rb
+++ b/lib/acts_as_list/active_record/acts/position_column_method_definer.rb
@@ -72,17 +72,18 @@ module ActiveRecord::Acts::List::PositionColumnMethodDefiner #:nodoc:
         cached_quoted_now = quoted_current_time_from_proper_timezone
 
         timestamp_attributes_for_update_in_model.map do |attr|
-          ", #{connection.quote_column_name(attr)} = #{cached_quoted_now}"
+          ", #{self.class.connection.quote_column_name(attr)} = #{cached_quoted_now}"
         end.join
       end
 
       private
 
-      delegate :connection, to: self
-
       def quoted_current_time_from_proper_timezone
-        connection.quote(connection.quoted_date(
-          current_time_from_proper_timezone))
+        self.class.connection.quote(
+          self.class.connection.quoted_date(
+            current_time_from_proper_timezone
+          )
+        )
       end
     end
   end


### PR DESCRIPTION
We ran into an issue with using `acts_as_list` on models that define a `connection` method or have a `connection` association (we have several). Any model with a `connection` association, for example, was raising an error on `save` as soon as `acts_as_list` was added:

```
     NoMethodError:
       undefined method `marked_for_destruction?' for #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x0000ffff67b71210 @transaction_manager=#<ActiveRecord::ConnectionAdapters::TransactionManager:0x0000ffff67b71198 @stack=[], @connection=#<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x0000ffff67b71210 ...>...>
```

This turned out to be because our `connection` association was being re-defined by `acts_as_list` with a `delegate :connection, to: :self`. Rails has no underlying problems with models having a `connection` instance method, and I believe typically you should be relying on the class to grab a connection rather than the instance/record.

Because it seems like this delegator is used only for convenience purposes, I think it should be dropped for compatibility reasons and replaced with more explicit calls to `self.class.connection`