### PR TITLE
gemspec: Remove test files, Gemfile from package

### DIFF
--- a/acts_as_list.gemspec
+++ b/acts_as_list.gemspec
@@ -23,7 +23,13 @@ Gem::Specification.new do |s|
   end
 
   # Load Paths...
-  s.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?(*%w[test/ Gemfile CHANGELOG]) }
+  gemspec = File.basename(__FILE__)
+  s.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
+    ls.readlines("\x0", chomp: true).reject do |f|
+      (f == gemspec) ||
+        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+    end
+  end
   s.executables   = `git ls-files -- bin/*`.split("\n").map {|f| File.basename(f)}
   s.require_paths = ["lib"]
 

--- a/acts_as_list.gemspec
+++ b/acts_as_list.gemspec
@@ -23,8 +23,7 @@ Gem::Specification.new do |s|
   end
 
   # Load Paths...
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files         = `git ls-files -z`.split("\x0").reject { |f| f.start_with?(*%w[test/ Gemfile CHANGELOG]) }
   s.executables   = `git ls-files -- bin/*`.split("\n").map {|f| File.basename(f)}
   s.require_paths = ["lib"]
 


### PR DESCRIPTION
This pull request updates the `*.gemspec` file to optimize the gem package size and structure. The changes include:

- Modified `files` to exclude test files, `Gemfile` ~~, and `CHANGELOG`~~ from the package.
- Removed the deprecated `test_files` specification as it is no longer recommended.

These changes reduce the extracted package size from **324 KB** to ~~**140 KB**~~ **160 KB**.

Benefits:

- Shorter download times for users
- Reduced container sizes when the gem is included

References:

- https://github.com/rubygems/guides/issues/90
- https://github.com/rubygems/bundler/pull/3207
- [Template for the `*.gemspec` file generated by `bundle gem` command](https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/templates/newgem/newgem.gemspec.tt)