### PR TITLE
Extend methods for retrieving next/previous items with conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,40 @@ In `acts_as_list`, "higher" means further up the list (a lower `position`), and 
 - `list_item.set_list_position(3)`
 
 ### Methods That Return Attributes of the Item's List Position
-- `list_item.first?`
-- `list_item.last?`
+- `list_item.first?` or `list_item.first?(conditions)`
+- `list_item.last?` or `list_item.last?(conditions)`
 - `list_item.in_list?`
 - `list_item.not_in_list?`
 - `list_item.default_position?`
-- `list_item.higher_item`
-- `list_item.higher_items` will return all the items above `list_item` in the list (ordered by the position, ascending)
-- `list_item.lower_item`
-- `list_item.lower_items` will return all the items below `list_item` in the list (ordered by the position, ascending)
+- `list_item.higher_item` or `list_item.higher_item(conditions)`
+- `list_item.higher_items` or `list_item.higher_items(conditions)` will return all the items above `list_item` in the list (ordered by the position, ascending)
+- `list_item.lower_item` or `list_item.lower_item(conditions)`
+- `list_item.lower_items` or `list_item.lower_items(conditions)` will return all the items below `list_item` in the list (ordered by the position, ascending)
+
+Example: Setting the position for all blogs, get the next/prev published blog
+
+```ruby
+class Blog < ActiveRecord::Base
+  acts_as_list
+  scope :published, -> { where(published: true) }
+end
+
+class BlogsController < ApplicationController
+  def show
+    @blog = Blog.published.find(params[:id])
+    @next_blog = @blog.lower_item(published: true) # next published blog
+    @prev_blog = @blog.higher_item(published: true) # previous published blog
+  end
+end
+
+class Admin::BlogsController < ApplicationController
+  def show
+    @blog = Blog.find(params[:id])
+    @next_blog = @blog.lower_item # next blog
+    @prev_blog = @blog.higher_item # previous blog
+  end
+end
+```
 
 ## Adding `acts_as_list` To An Existing Model
 As it stands `acts_as_list` requires position values to be set on the model before the instance methods above will work. Adding something like the below to your migration will set the default position. Change the parameters to order if you want a different initial ordering.

--- a/lib/acts_as_list/active_record/acts/list.rb
+++ b/lib/acts_as_list/active_record/acts/list.rb
@@ -149,48 +149,48 @@ module ActiveRecord
           set_list_position(current_position - 1)
         end
 
-        def first?
+        def first?(conditions = {})
           return false unless in_list?
-          !higher_items(1).exists?
+          !higher_items(1, conditions).exists?
         end
 
-        def last?
+        def last?(conditions = {})
           return false unless in_list?
-          !lower_items(1).exists?
+          !lower_items(1, conditions).exists?
         end
 
         # Return the next higher item in the list.
-        def higher_item
+        def higher_item(conditions = {})
           return nil unless in_list?
-          higher_items(1).first
+          higher_items(1, conditions).first
         end
 
         # Return the next n higher items in the list
         # selects all higher items by default
-        def higher_items(limit=nil)
+        def higher_items(limit=nil, conditions = {})
           limit ||= acts_as_list_list.count
-          acts_as_list_list.
-            where("#{quoted_position_column_with_table_name} <= ?", current_position).
-            where.not(primary_key_condition).
-            reorder(acts_as_list_order_argument(:desc)).
-            limit(limit)
+          query = acts_as_list_list.
+                    where("#{quoted_position_column_with_table_name} <= ?", current_position).
+                    where.not(primary_key_condition)
+          query = query.where(conditions) if conditions.present?
+          query.reorder(acts_as_list_order_argument(:desc)).limit(limit)
         end
 
         # Return the next lower item in the list.
-        def lower_item
+        def lower_item(conditions = {})
           return nil unless in_list?
-          lower_items(1).first
+          lower_items(1, conditions).first
         end
 
         # Return the next n lower items in the list
         # selects all lower items by default
-        def lower_items(limit=nil)
+        def lower_items(limit=nil, conditions = {})
           limit ||= acts_as_list_list.count
-          acts_as_list_list.
-            where("#{quoted_position_column_with_table_name} >= ?", current_position).
-            where.not(primary_key_condition).
-            reorder(acts_as_list_order_argument(:asc)).
-            limit(limit)
+          query = acts_as_list_list.
+                    where("#{quoted_position_column_with_table_name} >= ?", current_position).
+                    where.not(primary_key_condition)
+          query = query.where(conditions) if conditions.present?
+          query.reorder(acts_as_list_order_argument(:asc)).limit(limit)
         end
 
         # Test if this record is in a list

--- a/test/shared_list_sub.rb
+++ b/test/shared_list_sub.rb
@@ -108,6 +108,16 @@ module Shared
       assert_equal [li2, li1], li3.higher_items
     end
 
+    def test_next_prev_with_state_condition
+      ListMixin.update_all(state: 0)
+      ListMixin.where(id: 2).update_all(state: 1)
+      assert_equal [1, 2, 3, 4], ListMixin.where(parent_id: 5000).order('pos').map(&:id)
+      assert_equal ListMixin.where(id: 2).first, ListMixin.where(id: 1).first.lower_item
+      assert_equal ListMixin.where(id: 3).first, ListMixin.where(id: 1).first.lower_item(state: 0)
+      assert_equal ListMixin.where(id: 2).first, ListMixin.where(id: 3).first.higher_item
+      assert_equal ListMixin.where(id: 1).first, ListMixin.where(id: 3).first.higher_item(state: 0)
+    end
+
     def test_injection
       item = ListMixin.new("parent_id"=>1)
       assert_equal({ parent_id: 1 }, item.scope_condition)


### PR DESCRIPTION
There is a scenario where all blogs are positioned without any scope. In the frontend view, we need to retrieve the next/previous published blog. I hope this Pull Request can be accepted.

```ruby
class Blog < ActiveRecord::Base
  acts_as_list
  scope :published, -> { where(published: true) }
end

class BlogsController < ApplicationController
  def show
    @blog = Blog.published.find(params[:id])
    @next_blog = @blog.lower_item(published: true) # next published blog
    @prev_blog = @blog.higher_item(published: true) # previous published blog
  end
end

class Admin::BlogsController < ApplicationController
  def show
    @blog = Blog.find(params[:id])
    @next_blog = @blog.lower_item # next blog
    @prev_blog = @blog.higher_item # previous blog
  end
end
```