### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/acts_as_list.gemspec
+++ b/acts_as_list.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
     s.metadata['changelog_uri']   = 'https://github.com/brendon/acts_as_list/blob/master/CHANGELOG.md'
     s.metadata['source_code_uri'] = 'https://github.com/brendon/acts_as_list'
     s.metadata['bug_tracker_uri'] = 'https://github.com/brendon/acts_as_list/issues'
+    s.metadata['funding_uri']     = 'https://github.com/sponsors/brendon'
     s.metadata['rubygems_mfa_required'] = 'true'
   end
 


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.